### PR TITLE
Update README to not deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# THIS PACKAGE IS DEPRECATED
+
+[Reinforce.jl](https://github.com/JuliaML/Reinforce.jl) is discontinued. Please reference [CommonRLInterface](https://github.com/JuliaReinforcementLearning/CommonRLInterface.jl).
+
 # POMDPReinforce
 
 [![Build Status](https://travis-ci.org/etotheipluspi/POMDPReinforce.jl.svg?branch=master)](https://travis-ci.org/etotheipluspi/POMDPReinforce.jl)


### PR DESCRIPTION
Based on Reinforce.jl being deprecated, I think we should note that on the readme. Additionally, we might want to archive this package as well.